### PR TITLE
Coerce initializer parameter to_hash or to_h when it's not a Hash

### DIFF
--- a/lib/lift.rb
+++ b/lib/lift.rb
@@ -3,6 +3,11 @@ require "lift/version"
 module Lift
   def initialize(values = {})
     super()
+    unless values.respond_to? :each_pair
+      [:to_hash, :to_h].each do |hash_converter|
+        break values = values.send(hash_converter) if values.respond_to? hash_converter
+      end
+    end
     values.each_pair do |key, value|
       send "#{key}=", value
     end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -22,6 +22,26 @@ class AcceptanceTest < MiniTest::Unit::TestCase
     assert_equal 'ahawkins', person.nick
   end
 
+  def test_accepts_responds_to_to_h
+    hashy_class = Class.new do
+      def to_h
+        {nick: 'ahawkins'}
+      end
+    end
+    person = Person.new hashy_class.new
+    assert_equal 'ahawkins', person.nick
+  end
+
+  def test_accepts_responds_to_to_hash
+    hashy_class = Class.new do
+      def to_hash
+        {nick: 'ahawkins'}
+      end
+    end
+    person = Person.new hashy_class.new
+    assert_equal 'ahawkins', person.nick
+  end
+
   def test_works_with_a_block
     person = Person.new do |person|
       person.nick = 'ahawkins'


### PR DESCRIPTION
Passing hash-like objects that respond to #to_h or #to_hash will no longer fail to
work with lift's initializer when they didn't respond to #each_pair. Whenever we can
coerce the object to be a hash, do it, rather than forcing the caller to.

This can be used in situations like passing a JSON API response directly into the
initializer of a class that includes Lift, to create a value object out of the JSON
data.
